### PR TITLE
infer the types of files based on the extension in a case insensitive way

### DIFF
--- a/src/file.spec.ts
+++ b/src/file.spec.ts
@@ -61,6 +61,18 @@ describe('toFile()', () => {
         }
     });
 
+    it('sets the {type} from extension regardless of case', () => {
+        const types = Array.from(COMMON_MIME_TYPES.values());
+        const files = Array.from(COMMON_MIME_TYPES.keys())
+            .map(key => key.toUpperCase())
+            .map(ext => new File([], `test.${ext}`))
+            .map(f => toFileWithPath(f));
+
+        for (const file of files) {
+            expect(types.includes(file.type)).toBe(true);
+        }
+    });
+
     it('clones the File', () => {
         const opts: FilePropertyBag = {
             type: 'application/json',

--- a/src/file.ts
+++ b/src/file.ts
@@ -34,7 +34,7 @@ function withMimeType(file: File) {
 
     if (name && hasExtension && !file.type) {
         const ext = name.split('.')
-            .pop()!;
+            .pop()!.toLowerCase();
         const type = COMMON_MIME_TYPES.get(ext);
         if (type) {
             return clone(file, type);


### PR DESCRIPTION
Currently we only infer the file types if the extension is all lower case. This inference is required specifically in Firefox, other browsers seem to get the file type correctly from the file itself