### PR TITLE
Return full file paths on Electron.

### DIFF
--- a/src/file-selector.ts
+++ b/src/file-selector.ts
@@ -1,4 +1,4 @@
-import {FileWithPath, toFileWithPath} from './file';
+import {FileWithPath, ensureFileWithPath} from './file';
 
 
 const FILES_TO_IGNORE = [
@@ -27,10 +27,10 @@ function isDragEvt(value: any): value is DragEvent {
 function getInputFiles(evt: Event) {
     const files = isInput(evt.target)
         ? evt.target.files
-            ? fromList<File>(evt.target.files)
+            ? fromList<FileWithPath>(evt.target.files)
             : []
         : [];
-    return files.map(file => toFileWithPath(file));
+    return files.map(file => ensureFileWithPath(file));
 }
 
 function isInput(value: EventTarget | null): value is HTMLInputElement {
@@ -52,8 +52,8 @@ async function getDataTransferFiles(dt: DataTransfer, type: string) {
         return noIgnoredFiles(flatten<FileWithPath>(files));
     }
 
-    return noIgnoredFiles(fromList<File>(dt.files)
-        .map(file => toFileWithPath(file)));
+    return noIgnoredFiles(fromList<FileWithPath>(dt.files)
+        .map(file => ensureFileWithPath(file)));
 }
 
 function noIgnoredFiles(files: FileWithPath[]) {
@@ -106,7 +106,7 @@ function fromDataTransferItem(item: DataTransferItem) {
     if (!file) {
         return Promise.reject(`${item} is not a File`);
     }
-    const fwp = toFileWithPath(file);
+    const fwp = ensureFileWithPath(file);
     return Promise.resolve(fwp);
 }
 
@@ -153,8 +153,8 @@ function fromDirEntry(entry: any) {
 // https://developer.mozilla.org/en-US/docs/Web/API/FileSystemFileEntry
 async function fromFileEntry(entry: any) {
     return new Promise<FileWithPath>((resolve, reject) => {
-        entry.file((file: File) => {
-            const fwp = toFileWithPath(file, entry.fullPath);
+        entry.file((file: FileWithPath) => {
+            const fwp = ensureFileWithPath(file, entry.fullPath);
             resolve(fwp);
         }, (err: any) => {
             reject(err);

--- a/src/file-selector.ts
+++ b/src/file-selector.ts
@@ -1,4 +1,4 @@
-import {toFileWithPath, FileWithPath} from './file';
+import {FileWithPath, toFileWithPath} from './file';
 
 
 const FILES_TO_IGNORE = [

--- a/src/file-selector.ts
+++ b/src/file-selector.ts
@@ -1,4 +1,4 @@
-import {ensureFileWithPath, FileWithPath} from './file';
+import {toFileWithPath, FileWithPath} from './file';
 
 
 const FILES_TO_IGNORE = [
@@ -30,7 +30,7 @@ function getInputFiles(evt: Event) {
             ? fromList<FileWithPath>(evt.target.files)
             : []
         : [];
-    return files.map(file => ensureFileWithPath(file));
+    return files.map(file => toFileWithPath(file));
 }
 
 function isInput(value: EventTarget | null): value is HTMLInputElement {
@@ -53,7 +53,7 @@ async function getDataTransferFiles(dt: DataTransfer, type: string) {
     }
 
     return noIgnoredFiles(fromList<FileWithPath>(dt.files)
-        .map(file => ensureFileWithPath(file)));
+        .map(file => toFileWithPath(file)));
 }
 
 function noIgnoredFiles(files: FileWithPath[]) {
@@ -106,7 +106,7 @@ function fromDataTransferItem(item: DataTransferItem) {
     if (!file) {
         return Promise.reject(`${item} is not a File`);
     }
-    const fwp = ensureFileWithPath(file);
+    const fwp = toFileWithPath(file);
     return Promise.resolve(fwp);
 }
 
@@ -154,7 +154,7 @@ function fromDirEntry(entry: any) {
 async function fromFileEntry(entry: any) {
     return new Promise<FileWithPath>((resolve, reject) => {
         entry.file((file: FileWithPath) => {
-            const fwp = ensureFileWithPath(file, entry.fullPath);
+            const fwp = toFileWithPath(file, entry.fullPath);
             resolve(fwp);
         }, (err: any) => {
             reject(err);

--- a/src/file-selector.ts
+++ b/src/file-selector.ts
@@ -1,4 +1,4 @@
-import {FileWithPath, ensureFileWithPath} from './file';
+import {ensureFileWithPath, FileWithPath} from './file';
 
 
 const FILES_TO_IGNORE = [

--- a/src/file.spec.ts
+++ b/src/file.spec.ts
@@ -1,10 +1,10 @@
 // tslint:disable: forin
-import {COMMON_MIME_TYPES, ensureFileWithPath} from './file';
+import {COMMON_MIME_TYPES, toFileWithPath} from './file';
 
 describe('toFile()', () => {
     it('should be an instance of a File', () => {
         const file = new File([], 'test.json');
-        const fileWithPath = ensureFileWithPath(file);
+        const fileWithPath = toFileWithPath(file);
         expect(fileWithPath).toBeInstanceOf(File);
     });
 
@@ -12,7 +12,7 @@ describe('toFile()', () => {
         const type = 'application/json';
         const opts: FilePropertyBag = {type};
         const file = new File([], 'test.json', opts);
-        const fileWithPath = ensureFileWithPath(file);
+        const fileWithPath = toFileWithPath(file);
         expect(fileWithPath.type).toBe(type);
     });
 
@@ -22,21 +22,21 @@ describe('toFile()', () => {
         const file = new File([], 'test.json');
         // @ts-ignore
         file.path = fullPath; // this is set only in the case of an electron app
-        const fileWithPath = ensureFileWithPath(file, path);
+        const fileWithPath = toFileWithPath(file, path);
         expect(fileWithPath.path).toBe(fullPath);
     });
 
     it('sets the {path} if provided', () => {
         const path = '/test/test.json';
         const file = new File([], 'test.json');
-        const fileWithPath = ensureFileWithPath(file, path);
+        const fileWithPath = toFileWithPath(file, path);
         expect(fileWithPath.path).toBe(path);
     });
 
     test('{path} is enumerable', () => {
         const path = '/test/test.json';
         const file = new File([], 'test.json');
-        const fileWithPath = ensureFileWithPath(file, path);
+        const fileWithPath = toFileWithPath(file, path);
 
         expect(Object.keys(fileWithPath)).toContain('path');
 
@@ -51,7 +51,7 @@ describe('toFile()', () => {
     it('uses the File {name} as {path} if not provided', () => {
         const name = 'test.json';
         const file = new File([], name);
-        const fileWithPath = ensureFileWithPath(file);
+        const fileWithPath = toFileWithPath(file);
         expect(fileWithPath.path).toBe(name);
     });
 
@@ -61,7 +61,7 @@ describe('toFile()', () => {
         Object.defineProperty(file, 'webkitRelativePath', {
             value: path
         });
-        const fileWithPath = ensureFileWithPath(file);
+        const fileWithPath = toFileWithPath(file);
         expect(fileWithPath.path).toBe(path);
     });
 
@@ -69,7 +69,7 @@ describe('toFile()', () => {
         const types = Array.from(COMMON_MIME_TYPES.values());
         const files = Array.from(COMMON_MIME_TYPES.keys())
             .map(ext => new File([], `test.${ext}`))
-            .map(f => ensureFileWithPath(f));
+            .map(f => toFileWithPath(f));
 
         for (const file of files) {
             expect(types.includes(file.type)).toBe(true);
@@ -78,7 +78,7 @@ describe('toFile()', () => {
 
     test('{type} is enumerable', () => {
         const file = new File([], 'test.gif');
-        const fileWithPath = ensureFileWithPath(file);
+        const fileWithPath = toFileWithPath(file);
 
         expect(Object.keys(fileWithPath)).toContain('type');
 
@@ -95,7 +95,7 @@ describe('toFile()', () => {
         const files = Array.from(COMMON_MIME_TYPES.keys())
             .map(key => key.toUpperCase())
             .map(ext => new File([], `test.${ext}`))
-            .map(f => ensureFileWithPath(f));
+            .map(f => toFileWithPath(f));
 
         for (const file of files) {
             expect(types.includes(file.type)).toBe(true);
@@ -106,7 +106,7 @@ describe('toFile()', () => {
         const data = {ping: true};
         const json = JSON.stringify(data);
         const file = new File([json], 'test.json');
-        const fileWithPath = ensureFileWithPath(file);
+        const fileWithPath = toFileWithPath(file);
 
         const reader = new FileReader();
         reader.onload = evt => {

--- a/src/file.spec.ts
+++ b/src/file.spec.ts
@@ -1,10 +1,10 @@
 // tslint:disable: forin
-import {COMMON_MIME_TYPES, toFileWithPath} from './file';
+import {COMMON_MIME_TYPES, ensureFileWithPath} from './file';
 
 describe('toFile()', () => {
     it('should be an instance of a File', () => {
         const file = new File([], 'test.json');
-        const fileWithPath = toFileWithPath(file);
+        const fileWithPath = ensureFileWithPath(file);
         expect(fileWithPath).toBeInstanceOf(File);
     });
 
@@ -12,21 +12,31 @@ describe('toFile()', () => {
         const type = 'application/json';
         const opts: FilePropertyBag = {type};
         const file = new File([], 'test.json', opts);
-        const fileWithPath = toFileWithPath(file);
+        const fileWithPath = ensureFileWithPath(file);
         expect(fileWithPath.type).toBe(type);
+    });
+
+    it('does not overwrite {path} if it exists', () => {
+        const fullPath = '/Users/test/Desktop/test/test.json';
+        const path = '/test/test.json';
+        const file = new File([], 'test.json');
+        // @ts-ignore
+        file.path = fullPath; // this is set only in the case of an electron app
+        const fileWithPath = ensureFileWithPath(file, path);
+        expect(fileWithPath.path).toBe(fullPath);
     });
 
     it('sets the {path} if provided', () => {
         const path = '/test/test.json';
         const file = new File([], 'test.json');
-        const fileWithPath = toFileWithPath(file, path);
+        const fileWithPath = ensureFileWithPath(file, path);
         expect(fileWithPath.path).toBe(path);
     });
 
     test('{path} is enumerable', () => {
         const path = '/test/test.json';
         const file = new File([], 'test.json');
-        const fileWithPath = toFileWithPath(file, path);
+        const fileWithPath = ensureFileWithPath(file, path);
 
         expect(Object.keys(fileWithPath)).toContain('path');
 
@@ -41,7 +51,7 @@ describe('toFile()', () => {
     it('uses the File {name} as {path} if not provided', () => {
         const name = 'test.json';
         const file = new File([], name);
-        const fileWithPath = toFileWithPath(file);
+        const fileWithPath = ensureFileWithPath(file);
         expect(fileWithPath.path).toBe(name);
     });
 
@@ -51,7 +61,7 @@ describe('toFile()', () => {
         Object.defineProperty(file, 'webkitRelativePath', {
             value: path
         });
-        const fileWithPath = toFileWithPath(file);
+        const fileWithPath = ensureFileWithPath(file);
         expect(fileWithPath.path).toBe(path);
     });
 
@@ -59,7 +69,7 @@ describe('toFile()', () => {
         const types = Array.from(COMMON_MIME_TYPES.values());
         const files = Array.from(COMMON_MIME_TYPES.keys())
             .map(ext => new File([], `test.${ext}`))
-            .map(f => toFileWithPath(f));
+            .map(f => ensureFileWithPath(f));
 
         for (const file of files) {
             expect(types.includes(file.type)).toBe(true);
@@ -68,7 +78,7 @@ describe('toFile()', () => {
 
     test('{type} is enumerable', () => {
         const file = new File([], 'test.gif');
-        const fileWithPath = toFileWithPath(file);
+        const fileWithPath = ensureFileWithPath(file);
 
         expect(Object.keys(fileWithPath)).toContain('type');
 
@@ -85,7 +95,7 @@ describe('toFile()', () => {
         const files = Array.from(COMMON_MIME_TYPES.keys())
             .map(key => key.toUpperCase())
             .map(ext => new File([], `test.${ext}`))
-            .map(f => toFileWithPath(f));
+            .map(f => ensureFileWithPath(f));
 
         for (const file of files) {
             expect(types.includes(file.type)).toBe(true);
@@ -96,7 +106,7 @@ describe('toFile()', () => {
         const data = {ping: true};
         const json = JSON.stringify(data);
         const file = new File([json], 'test.json');
-        const fileWithPath = toFileWithPath(file);
+        const fileWithPath = ensureFileWithPath(file);
 
         const reader = new FileReader();
         reader.onload = evt => {

--- a/src/file.ts
+++ b/src/file.ts
@@ -15,22 +15,25 @@ export const COMMON_MIME_TYPES = new Map([
 ]);
 
 
-export function toFileWithPath(file: File, path?: string): FileWithPath {
+export function ensureFileWithPath(file: FileWithPath, path?: string): FileWithPath {
     const f = withMimeType(file);
-    const {webkitRelativePath} = file as FileWithWebkitPath;
-    Object.defineProperty(f, 'path', {
-        value: typeof path === 'string'
-            ? path
-            // If <input webkitdirectory> is set,
-            // the File will have a {webkitRelativePath} property
-            // https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/webkitdirectory
-            : typeof webkitRelativePath === 'string' && webkitRelativePath.length > 0
-                ? webkitRelativePath
-                : file.name,
-        writable: false,
-        configurable: false,
-        enumerable: true
-    });
+    if (!('path' in f)) { // on electron, path is already set to the absolute path
+        const {webkitRelativePath} = file as FileWithWebkitPath;
+        Object.defineProperty(f, 'path', {
+            value: typeof path === 'string'
+                ? path
+                // If <input webkitdirectory> is set,
+                // the File will have a {webkitRelativePath} property
+                // https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/webkitdirectory
+                : typeof webkitRelativePath === 'string' && webkitRelativePath.length > 0
+                    ? webkitRelativePath
+                    : file.name,
+            writable: false,
+            configurable: false,
+            enumerable: true
+        });
+    }
+
     return f;
 }
 
@@ -42,7 +45,7 @@ interface FileWithWebkitPath extends File {
     readonly webkitRelativePath?: string;
 }
 
-function withMimeType(file: File) {
+function withMimeType(file: FileWithPath) {
     const {name} = file;
     const hasExtension = name && name.lastIndexOf('.') !== -1;
 

--- a/src/file.ts
+++ b/src/file.ts
@@ -17,7 +17,7 @@ export const COMMON_MIME_TYPES = new Map([
 
 export function toFileWithPath(file: FileWithPath, path?: string): FileWithPath {
     const f = withMimeType(file);
-    if (!('path' in f)) { // on electron, path is already set to the absolute path
+    if (typeof f.path !== 'string') { // on electron, path is already set to the absolute path
         const {webkitRelativePath} = file as FileWithWebkitPath;
         Object.defineProperty(f, 'path', {
             value: typeof path === 'string'

--- a/src/file.ts
+++ b/src/file.ts
@@ -15,7 +15,7 @@ export const COMMON_MIME_TYPES = new Map([
 ]);
 
 
-export function ensureFileWithPath(file: FileWithPath, path?: string): FileWithPath {
+export function toFileWithPath(file: FileWithPath, path?: string): FileWithPath {
     const f = withMimeType(file);
     if (!('path' in f)) { // on electron, path is already set to the absolute path
         const {webkitRelativePath} = file as FileWithWebkitPath;


### PR DESCRIPTION
The file paths were being overwritten because that property doesn't exist on web but it does on electron.

The existing behaviour is identical on web and electron.

This PR will keep things unchanged on web and make the `path` property an absolute path on electron.

An alternative solution would be to rename the `path` that `react-dropzone` uses so it doesn't conflict.

Ref: https://github.com/react-dropzone/react-dropzone/issues/804