### PR TITLE
Fix conflicting file type

### DIFF
--- a/src/file.ts
+++ b/src/file.ts
@@ -42,6 +42,7 @@ interface _File extends Blob {
     readonly lastModified: number;
     readonly name: string;
 }
+
 export interface FileWithPath extends _File {
     readonly path?: string;
 }

--- a/src/file.ts
+++ b/src/file.ts
@@ -37,11 +37,16 @@ export function toFileWithPath(file: FileWithPath, path?: string): FileWithPath 
     return f;
 }
 
-export interface FileWithPath extends File {
+// Copy of File from lib.dom.d.ts with a different Name to prevent library collision
+interface _File extends Blob {
+    readonly lastModified: number;
+    readonly name: string;
+}
+export interface FileWithPath extends _File {
     readonly path?: string;
 }
 
-interface FileWithWebkitPath extends File {
+interface FileWithWebkitPath extends _File {
     readonly webkitRelativePath?: string;
 }
 


### PR DESCRIPTION
Potential fix for #12 by copying the `lib.dom.d.ts` interface. Not ideal since this *could* break if lib.dom changes but that seems less likely than people stepping on this conflict.