### PR TITLE
feat: add heic and heif MIME types

### DIFF
--- a/src/file.ts
+++ b/src/file.ts
@@ -21,7 +21,7 @@ export const COMMON_MIME_TYPES = new Map([
     ['gz', 'application/gzip'],
     ['gif', 'image/gif'],
     ['heic', 'image/heic'],
-    ['heic', 'image/heif'],
+    ['heif', 'image/heif'],
     ['htm', 'text/html'],
     ['html', 'text/html'],
     ['ico', 'image/vnd.microsoft.icon'],

--- a/src/file.ts
+++ b/src/file.ts
@@ -20,6 +20,8 @@ export const COMMON_MIME_TYPES = new Map([
     ['epub', 'application/epub+zip'],
     ['gz', 'application/gzip'],
     ['gif', 'image/gif'],
+    ['heic', 'image/heic'],
+    ['heic', 'image/heif'],
     ['htm', 'text/html'],
     ['html', 'text/html'],
     ['ico', 'image/vnd.microsoft.icon'],


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

- [ ] bugfix
- [x] feature
- [ ] refactoring / style
- [ ] build / chore
- [ ] documentation

**Did you add tests for your changes?**

- [ ] Yes, my code is well tested
- [x] Not relevant

**If relevant, did you update the documentation?**

- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

This PR adds support to `heic` and `heif` image types. Before, opening a file of these extensions always throw an error as the MIME type was not recognized.

https://github.com/react-dropzone/react-dropzone/issues/966

**Does this PR introduce a breaking change?**
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No breaking changes

**Other information**
