### PR TITLE
chore: remove `babel-jest` and related dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,12 +49,10 @@
     "tslib": "^2.4.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.17.10",
     "@rollup/plugin-commonjs": "^22.0.0",
     "@rollup/plugin-node-resolve": "^13.2.1",
     "@types/jest": "^27.4.1",
     "@types/node": "^17.0.30",
-    "babel-jest": "^28.0.3",
     "camelcase": "^6.3.0",
     "jest": "^28.0.3",
     "jest-environment-jsdom": "^28.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -36,7 +36,7 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.17.10.tgz#711dc726a492dfc8be8220028b1b92482362baab"
   integrity sha512-GZt/TCsG70Ms19gfZO1tM4CVnXsPgEPBCpJu+Qz3L0LUDsY5nZqFZglIoPC1kIYOtNBZlrnFT+klg12vFGZXrw==
 
-"@babel/core@^7.11.6", "@babel/core@^7.17.10":
+"@babel/core@^7.11.6":
   version "7.17.10"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.17.10.tgz#74ef0fbf56b7dfc3f198fc2d927f4f03e12f4b05"
   integrity sha512-liKoppandF3ZcBnIYFjfSDHZLKdLHGJRkoWtG8zQyGJBQfIYobpnVGI5+pLBNtS6psFLDzyq8+h5HiVljW9PNA==


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- [ ] Bug Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Style
- [ ] Build
- [x] Chore
- [ ] Documentation
- [ ] CI

**Did you add tests for your changes?**
- [ ] Yes, my code is well tested
- [x] Not relevant

**If relevant, did you update the documentation?**
- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**
Removes the `babel-jest` and `@babel/core` dependencies, as these are not used anywhere in the project. Likely this was used before, and subsequently replaced with `ts-jest`.

**Does this PR introduce a breaking change?**
No.

**Other information**
None.