### PR TITLE
feat: add FileSystemFileHandle support

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Most browser support basic File selection with drag 'n' drop or file input:
 * [File API](https://developer.mozilla.org/en-US/docs/Web/API/File#Browser_compatibility)
 * [Drag Event](https://developer.mozilla.org/en-US/docs/Web/API/DragEvent#Browser_compatibility)
 * [DataTransfer](https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer#Browser_compatibility)
+* [DataTransferItem.getAsFileSystemHandle()](https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItem/getAsFileSystemHandle)
 * [`<input type="file">`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#Browser_compatibility)
 
 For folder drop we use the [FileSystem API](https://developer.mozilla.org/en-US/docs/Web/API/FileSystem) which has very limited support:

--- a/src/file-selector.ts
+++ b/src/file-selector.ts
@@ -121,6 +121,10 @@ function flatten<T>(items: any[]): T[] {
 }
 
 function fromDataTransferItem(item: DataTransferItem) {
+    if ('getAsFileSystemHandle' in DataTransferItem.prototype) {
+        return item.getAsFileSystemHandle().then((fileSystemHandle: any) => fileSystemHandle.getFile())
+            .catch((error: { message: any; }) => error.message);
+    }
     const file = item.getAsFile();
     if (!file) {
         return Promise.reject(`${item} is not a File`);

--- a/src/file-selector.ts
+++ b/src/file-selector.ts
@@ -122,7 +122,7 @@ function flatten<T>(items: any[]): T[] {
 
 function fromDataTransferItem(item: DataTransferItem) {
     if ('getAsFileSystemHandle' in DataTransferItem.prototype) {
-        return item.getAsFileSystemHandle().then((fileSystemHandle: any) => fileSystemHandle.getFile())
+        return (item as any).getAsFileSystemHandle().then((fileSystemHandle: any) => fileSystemHandle.getFile())
             .catch((error: { message: any; }) => error.message);
     }
     const file = item.getAsFile();

--- a/src/file-selector.ts
+++ b/src/file-selector.ts
@@ -126,7 +126,7 @@ function fromDataTransferItem(item: DataTransferItem) {
             const file = fileSystemHandle.getFile();
             file.handle = fileSystemHandle;
             return file;
-        }).catch((error: { message: any; }) => error.message);
+        });
     }
     const file = item.getAsFile();
     if (!file) {

--- a/src/file-selector.ts
+++ b/src/file-selector.ts
@@ -122,8 +122,11 @@ function flatten<T>(items: any[]): T[] {
 
 function fromDataTransferItem(item: DataTransferItem) {
     if ('getAsFileSystemHandle' in DataTransferItem.prototype) {
-        return (item as any).getAsFileSystemHandle().then((fileSystemHandle: any) => fileSystemHandle.getFile())
-            .catch((error: { message: any; }) => error.message);
+        return (item as any).getAsFileSystemHandle().then((fileSystemHandle: any) => {
+            const file = fileSystemHandle.getFile();
+            file.handle = fileSystemHandle;
+            return file;
+        }).catch((error: { message: any; }) => error.message);
     }
     const file = item.getAsFile();
     if (!file) {


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- [ ] Bug Fix
- [X] Feature (Fixes https://github.com/react-dropzone/react-dropzone/issues/1271)
- [ ] Refactoring
- [ ] Style
- [ ] Build
- [ ] Chore
- [ ] Documentation
- [ ] CI

**Did you add tests for your changes?**
- [ ] Yes, my code is well tested
- [ ] Not relevant

I think TypeScript doesn't know about this feature yet: `Property 'getAsFileSystemHandle' does not exist on type 'DataTransferItem'.`.

**If relevant, did you update the documentation?**
- [X] Yes, I've updated the documentation
- [ ] Not relevant

**Summary**
Dropped files could be edited right away (instead of forcing a download of a copy), which would be a great win for apps that need to modify dropped files, like online image editors. Also see the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItem/getAsFileSystemHandle).

**Does this PR introduce a breaking change?**
If this PR introduces a breaking change, please describe the impact and a migration path for existing applications.

**Other information**
Sorry, I don't know much TypeScript. This will need someone to teach TypeScript that 'getAsFileSystemHandle' exists on type 'DataTransferItem'. I wasn't sure how to test this in, since the tests fail because of the TypeScript issue.  