### PR TITLE
chore!: drop support for legacy Node.js versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14, 16, 18, 20, 22]
+        node_version: [18, 20, 22]
 
     steps:
       - name: Checkout repository
@@ -25,10 +25,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-
-      - name: Install compatible NPM version
-        if: matrix.node-version == 14
-        run: npm install -g npm@^9
 
       - name: Install dependencies
         run: npm ci

--- a/package.json
+++ b/package.json
@@ -64,6 +64,6 @@
     "typescript": "^5.6.2"
   },
   "engines": {
-    "node": ">= 12"
+    "node": ">=18"
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: drops support for all legacy Node.js versions (below version 18)

**What kind of change does this PR introduce?**
- [ ] Bug Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Style
- [ ] Build
- [x] Chore
- [ ] Documentation
- [ ] CI

**Did you add tests for your changes?**
- [ ] Yes, my code is well tested
- [x] Not relevant

**If relevant, did you update the documentation?**
- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**
Drops support for versions of Node.js that no longer receive active support. This simplifies the CI and makes it easier to do future maintenance.

**Does this PR introduce a breaking change?**
Yes, this drops support for any version of Node.js older than 18. Realistically though this library is likely not often used in a Node.js environment, so this should not affect many users.

**Other information**
None.