### PR TITLE
feat!: always set a {relativePath}

### DIFF
--- a/src/file-selector.ts
+++ b/src/file-selector.ts
@@ -110,7 +110,7 @@ function toFilePromises(item: DataTransferItem) {
         return fromDirEntry(entry) as any;
     }
 
-    return fromDataTransferItem(item);
+    return fromDataTransferItem(item, entry);
 }
 
 function flatten<T>(items: any[]): T[] {
@@ -120,7 +120,7 @@ function flatten<T>(items: any[]): T[] {
     ], []);
 }
 
-function fromDataTransferItem(item: DataTransferItem) {
+function fromDataTransferItem(item: DataTransferItem, entry?: FileSystemEntry | null) {
     if (typeof (item as any).getAsFileSystemHandle === 'function') {
         return (item as any).getAsFileSystemHandle()
             .then(async (h: any) => {
@@ -133,7 +133,7 @@ function fromDataTransferItem(item: DataTransferItem) {
     if (!file) {
         return Promise.reject(`${item} is not a File`);
     }
-    const fwp = toFileWithPath(file);
+    const fwp = toFileWithPath(file, entry?.fullPath ?? undefined);
     return Promise.resolve(fwp);
 }
 

--- a/src/file.spec.ts
+++ b/src/file.spec.ts
@@ -52,7 +52,7 @@ describe('toFile()', () => {
         const name = 'test.json';
         const file = new File([], name);
         const fileWithPath = toFileWithPath(file);
-        expect(fileWithPath.path).toBe(name);
+        expect(fileWithPath.path).toBe(`./${name}`);
     });
 
     it('uses the File {webkitRelativePath} as {path} if it exists', () => {
@@ -64,6 +64,44 @@ describe('toFile()', () => {
         });
         const fileWithPath = toFileWithPath(file);
         expect(fileWithPath.path).toBe(path);
+    });
+
+    it('sets the {relativePath} if provided without overwriting {path}', () => {
+        const fullPath = '/Users/test/Desktop/test/test.json';
+        const path = '/test/test.json';
+        const file = new File([], 'test.json');
+
+        // @ts-expect-error
+        file.path = fullPath;
+        const fileWithPath = toFileWithPath(file, path);
+        expect(fileWithPath.path).toBe(fullPath);
+        expect(fileWithPath.relativePath).toBe(path);
+    });
+
+    test('{relativePath} is enumerable', () => {
+        const path = '/test/test.json';
+        const file = new File([], 'test.json');
+        const fileWithPath = toFileWithPath(file, path);
+
+        expect(Object.keys(fileWithPath)).toContain('relativePath');
+
+        const keys: string[] = [];
+        for (const key in fileWithPath) {
+            keys.push(key);
+        }
+
+        expect(keys).toContain('relativePath');
+    });
+
+    it('uses the File {webkitRelativePath} as {relativePath} if it exists', () => {
+        const name = 'test.json';
+        const path = 'test/test.json';
+        const file = new File([], name);
+        Object.defineProperty(file, 'webkitRelativePath', {
+            value: path
+        });
+        const fileWithPath = toFileWithPath(file);
+        expect(fileWithPath.relativePath).toBe(path);
     });
 
     it('sets the {type} from extension', () => {


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- [ ] Bug Fix
- [x] Feature
- [ ] Refactoring
- [ ] Style
- [ ] Build
- [ ] Chore
- [ ] Documentation
- [ ] CI

**Did you add tests for your changes?**
- [x] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**
- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**
Explain the **motivation** for making this change. What existing problem does the pull request solve?
Try to link to an open issue for more information.

Address https://github.com/react-dropzone/file-selector/issues/69.

**Does this PR introduce a breaking change?**
If this PR introduces a breaking change, please describe the impact and a migration path for existing applications.

Yes. The `path` will be relative when falling back to the file name:
```
// before
console.log(file.path)
// test.json

// after
console.log(file.path)
// ./test.json
```

**Other information**

Original PR at https://github.com/react-dropzone/file-selector/pull/70.