### PR TITLE
chore: only collect coverage on latest Node.js version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,20 +71,13 @@ jobs:
         run: npm ci
 
       - name: Run tests
+        if: matrix.node-version != 22
+        run: npm test -- --coverage
+
+      - name: Run tests with coverage
+        if: matrix.node-version == 22
         run: npm test -- --coverage
 
       - name: Collect coverage
+        if: matrix.node-version == 22
         uses: coverallsapp/github-action@v2
-        with:
-          flag-name: run-${{ join(matrix.*, '-') }}
-          parallel: true
-
-  coverage:
-    name: Publish coverage
-    needs: test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Publish coverage
-        uses: coverallsapp/github-action@v2
-        with:
-          parallel-finished: true


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- [ ] Bug Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Style
- [ ] Build
- [x] Chore
- [ ] Documentation
- [ ] CI

**Did you add tests for your changes?**
- [ ] Yes, my code is well tested
- [x] Not relevant

**If relevant, did you update the documentation?**
- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**
Runs the coverage collection of the tests only when running on the latest version of Node.js. Since the Node.js version should not affect the coverage result this should have no negative effects. This also cleans up the workflow so it is less complex and reduces the amount of jobs and time spend on them.

**Does this PR introduce a breaking change?**
No.

**Other information**
Not relevant.