### PR TITLE
refactor: clean up file system entry retrieval

### DIFF
--- a/src/file-selector.spec.ts
+++ b/src/file-selector.spec.ts
@@ -75,6 +75,22 @@ it("should return an empty array if the passed event is not a DragEvent", async 
   expect(files).toHaveLength(0);
 });
 
+it("should return an empty array if the dragged item not a directory or file", async () => {
+  const evt = dragEvtFromItems([
+    dataTransferItemFromEntry(
+      fileSystemDirEntryFromFile([
+        {
+          isDirectory: false,
+          isFile: false,
+        } as FileEntry,
+      ]),
+    ),
+  ]);
+
+  const files = await fromEvent(evt);
+  expect(files).toHaveLength(0);
+});
+
 it("should return files from DataTransfer {items} if the passed event is a DragEvent", async () => {
   const name = "test.json";
   const mockFile = createFile(


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- [ ] Bug Fix
- [ ] Feature
- [x] Refactoring
- [ ] Style
- [ ] Build
- [ ] Chore
- [ ] Documentation
- [ ] CI

**Did you add tests for your changes?**
- [ ] Yes, my code is well tested
- [x] Not relevant

**If relevant, did you update the documentation?**
- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**
Cleans up the code that retrieves and processes file system entries so that the flow is easier to follow. This is done by wrapping methods such as `readEntries()` and `file()` and 'promisifying' their callback style to promises, which allows them to be `await`ed.

Additionally, this PR re-structures the `fromDirEntry()` function to use the above and uses a `while` loop to drain the directory reader until there are no more entries to read. This simplifies the code and improves readability as it is no longer required to jump through various functions and manually manage the promise with `resolve()` and `reject()` calls.

Type safety is also improved by adding proper type definitions to all the affected code.

**Does this PR introduce a breaking change?**
No

**Other information**
This is a cleanup, but also I am going through and selectively re-writing code to get more familiar with the code-base.