### PR TITLE
fix: don't collect coverage on older Node.js

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Run tests
         if: matrix.node-version != 22
-        run: npm test -- --coverage
+        run: npm test
 
       - name: Run tests with coverage
         if: matrix.node-version == 22


### PR DESCRIPTION
Had a small mistake in my previous PR, so coverage was still being collected even when not needed.