### PR TITLE
fix: use getAsFileSystemHandle only in secure ctx

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,9 @@
-/** @type {import('ts-jest').JestConfigWithTsJest} **/
+/** @type {import('ts-jest').ProjectConfigTsJest} **/
 module.exports = {
     testEnvironment: 'jsdom',
+    "setupFilesAfterEnv": [
+      "<rootDir>/test-setup.js"
+    ],
     transform: {
       '^.+.tsx?$': [
         'ts-jest',

--- a/src/file-selector.spec.ts
+++ b/src/file-selector.spec.ts
@@ -304,6 +304,35 @@ it('should use getAsFileSystemHandle when available', async () => {
     expect(file.path).toBe(`./${name}`);
 });
 
+it('should not use getAsFileSystemHandle when not in a secure context', async () => {
+    const f1Name = 'test.nosec.json';
+    const f1 = createFile(f1Name, {ping: false}, {
+        type: 'application/json'
+    });
+    const [_, h] = createFileSystemFileHandle('test.sec.json', {ping: true}, {
+        type: 'application/json'
+    });
+    const evt = dragEvtFromItems([
+        dataTransferItemWithFsHandle(f1, h)
+    ]);
+
+    window.isSecureContext = false;
+
+    const files = await fromEvent(evt);
+    expect(files).toHaveLength(1);
+    expect(files.every(file => file instanceof File)).toBe(true);
+
+    const [file] = files as FileWithPath[];
+
+    expect(file.name).toBe(f1.name);
+    expect(file.type).toBe(f1.type);
+    expect(file.size).toBe(f1.size);
+    expect(file.lastModified).toBe(f1.lastModified);
+    expect(file.path).toBe(`./${f1Name}`);
+
+    window.isSecureContext = true;
+});
+
 function dragEvtFromItems(items: DataTransferItem | DataTransferItem[], type: string = 'drop'): DragEvent {
     return {
         type,
@@ -466,8 +495,7 @@ function createFile<T>(name: string, data: T, options?: FilePropertyBag) {
 }
 
 function createFileSystemFileHandle<T>(name: string, data: T, options?: FilePropertyBag): [File, FileSystemFileHandle] {
-    const json = JSON.stringify(data);
-    const file = new File([json], name, options);
+    const file = createFile(name, data, options);
     return [file, {
         getFile() {
             return Promise.resolve(file);

--- a/src/file-selector.ts
+++ b/src/file-selector.ts
@@ -121,7 +121,13 @@ function flatten<T>(items: any[]): T[] {
 }
 
 function fromDataTransferItem(item: DataTransferItem, entry?: FileSystemEntry | null) {
-    if (typeof (item as any).getAsFileSystemHandle === 'function') {
+    // Check if we're in a secure context; due to a bug in Chrome (as far as we know)
+    // the browser crashes when calling this API (yet to be confirmed as a consistent behaviour).
+    //
+    // See:
+    // - https://issues.chromium.org/issues/40186242
+    // - https://github.com/react-dropzone/react-dropzone/issues/1397
+    if (globalThis.isSecureContext && typeof (item as any).getAsFileSystemHandle === 'function') {
         return (item as any).getAsFileSystemHandle()
             .then(async (h: any) => {
                 const file = await h.getFile();

--- a/test-setup.js
+++ b/test-setup.js
@@ -1,0 +1,6 @@
+// NOTE: Let us test {isSecureContext}!
+Object.defineProperty(globalThis, "isSecureContext", {
+  value: true,
+  writable: true,
+  enumerable: true,
+});


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- [x] Bug Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Style
- [ ] Build
- [ ] Chore
- [ ] Documentation
- [ ] CI

**Did you add tests for your changes?**
- [x] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**
- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**

Potential fix for https://github.com/react-dropzone/react-dropzone/issues/1397.

**Does this PR introduce a breaking change?**

No.

**Other information**
