### PR TITLE
fix: use getAsFileSystemHandle only in secure ctx

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,6 +10,7 @@ const jestConfig = {
   moduleNameMapper: {
     "^(\\.{1,2}/.*)\\.js$": "$1",
   },
+  setupFilesAfterEnv: ["<rootDir>/test-setup.js"],
 };
 
 export default jestConfig;

--- a/src/file-selector.ts
+++ b/src/file-selector.ts
@@ -109,7 +109,15 @@ function fromDataTransferItem(
   item: DataTransferItem,
   entry?: FileSystemEntry | null,
 ) {
-  if (typeof (item as any).getAsFileSystemHandle === "function") {
+  // Check if we're in a secure context; due to a bug in Chrome (as far as we know) the browser crashes when calling this API (yet to be confirmed as a consistent behavior).
+  //
+  // See:
+  // - https://issues.chromium.org/issues/40186242
+  // - https://github.com/react-dropzone/react-dropzone/issues/1397
+  if (
+    globalThis.isSecureContext &&
+    typeof (item as any).getAsFileSystemHandle === "function"
+  ) {
     return (item as any).getAsFileSystemHandle().then(async (h: any) => {
       const file = await h.getFile();
       file.handle = h;

--- a/test-setup.js
+++ b/test-setup.js
@@ -1,0 +1,6 @@
+// NOTE: Let us test {isSecureContext}!
+Object.defineProperty(globalThis, "isSecureContext", {
+  value: true,
+  writable: true,
+  enumerable: true,
+});


### PR DESCRIPTION
This PR backports #116 on top of the `beta` branch, slightly modified so that it matches the code conventions that have changed.