### PR TITLE
feat: use a custom error when items are not files

### DIFF
--- a/src/error.spec.ts
+++ b/src/error.spec.ts
@@ -1,0 +1,17 @@
+import {UnexpectedObjectError} from './error';
+
+describe('UnexpectedObjectError', () => {
+    it('works as expected', () => {
+        const item = {it: 'works'};
+        try {
+            throw new UnexpectedObjectError(item as any);
+        } catch (e: any) {
+            expect(e.name).toEqual('UnexpectedObjectError');
+            expect(e.toString()).toEqual('UnexpectedObjectError: DataTransferItem is not a file');
+            expect(e).toBeInstanceOf(Error);
+            expect(e).toBeInstanceOf(UnexpectedObjectError);
+            expect(e.item).toEqual(item);
+            expect(e.stack).toBeDefined();
+        }
+    });
+});

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,0 +1,8 @@
+export class UnexpectedObjectError extends Error {
+    item: DataTransferItem;
+    constructor(item: DataTransferItem) {
+        super('DataTransferItem is not a file');
+        this.item = item;
+        this.name = 'UnexpectedObjectError';
+    }
+}

--- a/src/file-selector.spec.ts
+++ b/src/file-selector.spec.ts
@@ -337,7 +337,7 @@ it('should reject when getAsFileSystemHandle resolves to null', async () => {
     const evt = dragEvtFromItems([
         dataTransferItemWithFsHandle(null, null)
     ]);
-    expect(fromEvent(evt)).rejects.toThrow('[object Object] is not a File');
+    expect(fromEvent(evt)).rejects.toThrow('DataTransferItem is not a file');
 });
 
 it('should fallback to getAsFile when getAsFileSystemHandle resolves to undefined', async () => {

--- a/src/file-selector.ts
+++ b/src/file-selector.ts
@@ -1,5 +1,5 @@
+import {UnexpectedObjectError} from './error';
 import {FileWithPath, toFileWithPath} from './file';
-
 
 const FILES_TO_IGNORE = [
     // Thumbnail cache files for macOS and Windows
@@ -130,7 +130,7 @@ async function fromDataTransferItem(item: DataTransferItem, entry?: FileSystemEn
     if (globalThis.isSecureContext && typeof (item as any).getAsFileSystemHandle === 'function') {
         const h = await (item as any).getAsFileSystemHandle();
         if (h === null) {
-            throw new Error(`${item} is not a File`);
+            throw new UnexpectedObjectError(item);
         }
         // It seems that the handle can be `undefined` (see https://github.com/react-dropzone/file-selector/issues/120),
         // so we check if it isn't; if it is, the code path continues to the next API (`getAsFile`).
@@ -142,7 +142,7 @@ async function fromDataTransferItem(item: DataTransferItem, entry?: FileSystemEn
     }
     const file = item.getAsFile();
     if (!file) {
-        throw new Error(`${item} is not a File`);
+        throw new UnexpectedObjectError(item);
     }
     const fwp = toFileWithPath(file, entry?.fullPath ?? undefined);
     return fwp;


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- [ ] Bug Fix
- [x] Feature
- [ ] Refactoring
- [ ] Style
- [ ] Build
- [ ] Chore
- [ ] Documentation
- [ ] CI

**Did you add tests for your changes?**
- [x] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**
- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**

Use a custom error for the `not a file` case so that users can inspect the item if they wish to.

**Does this PR introduce a breaking change?**

Probably not.

**Other information**
