### PR TITLE
refactor!: split file handles into seperate function

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,15 +107,12 @@ input.addEventListener("change", async (event) => {
 Convert [FileSystemFileHandle](https://developer.mozilla.org/en-US/docs/Web/API/FileSystemFileHandle) items to File objects:
 
 ```js
-import { fromEvent } from "file-selector";
+import { fromFileHandles } from "file-selector";
 
 const handles = await window.showOpenFilePicker({ multiple: true });
-const files = await fromEvent(handles);
+const files = await fromFileHandles(handles);
 console.log(files);
 ```
-
-> [!NOTE]
-> The above is experimental and subject to change.
 
 ## Browser Support
 

--- a/src/file-selector.spec.ts
+++ b/src/file-selector.spec.ts
@@ -1,5 +1,5 @@
 import { FileWithPath } from "./file.js";
-import { fromEvent } from "./file-selector.js";
+import { fromEvent, fromFileHandles } from "./file-selector.js";
 
 it("returns a Promise", async () => {
   const evt = new Event("test");
@@ -46,27 +46,29 @@ it("should return an empty array if the evt {target} has no {files} prop", async
   expect(files).toHaveLength(0);
 });
 
-it("should return files if the arg is a list of FileSystemFileHandle", async () => {
-  const name = "test.json";
-  const [mockFile, mockHandle] = createFileSystemFileHandle(
-    name,
-    { ping: true },
-    {
-      type: "application/json",
-    },
-  );
+describe("fromFileHandles", () => {
+  it("retrieves files from file handles", async () => {
+    const name = "test.json";
+    const [mockFile, mockHandle] = createFileSystemFileHandle(
+      name,
+      { ping: true },
+      {
+        type: "application/json",
+      },
+    );
 
-  const files = await fromEvent([mockHandle]);
-  expect(files).toHaveLength(1);
-  expect(files.every((file) => file instanceof File)).toBe(true);
+    const files = await fromFileHandles([mockHandle]);
+    expect(files).toHaveLength(1);
+    expect(files.every((file) => file instanceof File)).toBe(true);
 
-  const [file] = files as FileWithPath[];
+    const [file] = files as FileWithPath[];
 
-  expect(file.name).toBe(mockFile.name);
-  expect(file.type).toBe(mockFile.type);
-  expect(file.size).toBe(mockFile.size);
-  expect(file.lastModified).toBe(mockFile.lastModified);
-  expect(file.path).toBe(`./${name}`);
+    expect(file.name).toBe(mockFile.name);
+    expect(file.type).toBe(mockFile.type);
+    expect(file.size).toBe(mockFile.size);
+    expect(file.lastModified).toBe(mockFile.lastModified);
+    expect(file.path).toBe(`./${name}`);
+  });
 });
 
 it("should return an empty array if the passed event is not a DragEvent", async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
-export { fromEvent } from "./file-selector.js";
+export { fromEvent, fromFileHandles } from "./file-selector.js";
 export { FileWithPath } from "./file.js";


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- [ ] Bug Fix
- [ ] Feature
- [x] Refactoring
- [ ] Style
- [ ] Build
- [ ] Chore
- [ ] Documentation
- [ ] CI

**Did you add tests for your changes?**
- [x] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**
- [x] Yes, I've updated the documentation
- [ ] Not relevant

**Summary**
Removes the handling of `FileSystemFileHandle` arrays from the `fromEvent()` function, and moves it to a dedicated `fromFileHandles()` function purposefully made for handling this data type. This reduces the need to handle polymorphic input and narrow down what the exact type should be in `fromEvent()`. Additionally, this allows bundlers to more effectively tree-shake the module in case the other code is never used. The JSDoc on the function itself has also been improved with additional details for the consumer.

**Does this PR introduce a breaking change?**
Yes, arrays of `FileSystemFileHandle` are now handled in a dedicated `fromFileHandles()` function. Users that were previously using `fromEvent()` will now have to use this dedicated function instead.

**Other information**
This also removes the notice that this feature is experimental, promoting `fromFileHandles()` to a stable API in the next major.