### PR TITLE
refactor: remove ie11 artifacts

### DIFF
--- a/src/file-selector.spec.ts
+++ b/src/file-selector.spec.ts
@@ -75,30 +75,6 @@ it('should return an empty array if the passed event is not a DragEvent', async 
     expect(files).toHaveLength(0);
 });
 
-it('should return {files} from DataTransfer if {items} is not defined (e.g. IE11)', async () => {
-    const name = 'test.json';
-    const mockFile = createFile(
-        name,
-        {ping: true},
-        {
-            type: 'application/json'
-        }
-    );
-    const evt = dragEvt([mockFile]);
-
-    const files = await fromEvent(evt);
-    expect(files).toHaveLength(1);
-    expect(files.every(file => file instanceof File)).toBe(true);
-
-    const [file] = files as FileWithPath[];
-
-    expect(file.name).toBe(mockFile.name);
-    expect(file.type).toBe(mockFile.type);
-    expect(file.size).toBe(mockFile.size);
-    expect(file.lastModified).toBe(mockFile.lastModified);
-    expect(file.path).toBe(`./${name}`);
-});
-
 it('should return files from DataTransfer {items} if the passed event is a DragEvent', async () => {
     const name = 'test.json';
     const mockFile = createFile(
@@ -324,7 +300,7 @@ it('filters thumbnail cache files', async () => {
             type: 'text/plain'
         }
     );
-    const evt = dragEvt([mockFile]);
+    const evt = dragEvtFromItems([dataTransferItemFromFile(mockFile)]);
     const items = await fromEvent(evt);
     expect(items).toHaveLength(0);
 });
@@ -424,7 +400,7 @@ it('should not use getAsFileSystemHandle when not in a secure context', async ()
 
 it('should reject when getAsFileSystemHandle resolves to null', async () => {
     const evt = dragEvtFromItems([dataTransferItemWithFsHandle(null, null)]);
-    expect(fromEvent(evt)).rejects.toThrow('DataTransferItem is not a file');
+    await expect(fromEvent(evt)).rejects.toThrow('DataTransferItem is not a file');
 });
 
 it('should fallback to getAsFile when getAsFileSystemHandle resolves to undefined', async () => {
@@ -457,13 +433,6 @@ function dragEvtFromItems(items: DataTransferItem | DataTransferItem[], type: st
         dataTransfer: {
             items: Array.isArray(items) ? items : [items]
         }
-    } as any;
-}
-
-function dragEvt(files?: File[], items?: DataTransferItem[], type: string = 'drop'): DragEvent {
-    return {
-        type,
-        dataTransfer: {items, files}
     } as any;
 }
 

--- a/src/file-selector.ts
+++ b/src/file-selector.ts
@@ -51,43 +51,28 @@ async function getFsHandleFiles(handles: any[]) {
 }
 
 async function getDataTransferFiles(dt: DataTransfer, type: string) {
-    // IE11 does not support dataTransfer.items
-    // See https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/items#Browser_compatibility
-    if (dt.items) {
-        const items = fromList<DataTransferItem>(dt.items).filter(item => item.kind === 'file');
-        // According to https://html.spec.whatwg.org/multipage/dnd.html#dndevents,
-        // only 'dragstart' and 'drop' has access to the data (source node)
-        if (type !== 'drop') {
-            return items;
-        }
-        const files = await Promise.all(items.map(toFilePromises));
-        return noIgnoredFiles(flatten<FileWithPath>(files));
+    const items = fromList<DataTransferItem>(dt.items).filter(item => item.kind === 'file');
+    // According to https://html.spec.whatwg.org/multipage/dnd.html#dndevents,
+    // only 'dragstart' and 'drop' has access to the data (source node)
+    if (type !== 'drop') {
+        return items;
     }
-
-    return noIgnoredFiles(fromList<FileWithPath>(dt.files).map(file => toFileWithPath(file)));
+    const files = await Promise.all(items.map(toFilePromises));
+    return noIgnoredFiles(flatten<FileWithPath>(files));
 }
 
 function noIgnoredFiles(files: FileWithPath[]) {
     return files.filter(file => FILES_TO_IGNORE.indexOf(file.name) === -1);
 }
 
-// IE11 does not support Array.from()
-// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from#Browser_compatibility
 // https://developer.mozilla.org/en-US/docs/Web/API/FileList
 // https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItemList
 function fromList<T>(items: DataTransferItemList | FileList | null): T[] {
+    // {items} can be null, e.g. an <input type="file"> with no selection
     if (items === null) {
         return [];
     }
-
-    const files = [];
-
-    for (let i = 0; i < items.length; i++) {
-        const file = items[i];
-        files.push(file);
-    }
-
-    return files as any;
+    return Array.from(items as unknown as ArrayLike<T>);
 }
 
 // https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItem


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- [ ] Bug Fix
- [ ] Feature
- [x] Refactoring
- [ ] Style
- [ ] Build
- [ ] Chore
- [ ] Documentation
- [ ] CI

**Did you add tests for your changes?**
- [x] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**
- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**

Get rid of IE11 comments and workarounds. Keep defensive checks

**Does this PR introduce a breaking change?**

No.

**Other information**

Stacked on top of:
1. https://github.com/react-dropzone/file-selector/pull/133
2. https://github.com/react-dropzone/file-selector/pull/135
3. https://github.com/react-dropzone/file-selector/pull/136