### PR TITLE
fix: make FileWithPath{path, relativePath} required

### DIFF
--- a/src/file.spec.ts
+++ b/src/file.spec.ts
@@ -54,6 +54,13 @@ describe('toFile()', () => {
         expect(fileWithPath.path).toBe(`./${name}`);
     });
 
+    it('always sets {path} and {relativePath} to a string, even for a bare File', () => {
+        const file = new File([], 'test.json');
+        const fileWithPath = toFileWithPath(file);
+        expect(typeof fileWithPath.path).toBe('string');
+        expect(typeof fileWithPath.relativePath).toBe('string');
+    });
+
     it('uses the File {webkitRelativePath} as {path} if it exists', () => {
         const name = 'test.json';
         const path = 'test/test.json';

--- a/src/file.ts
+++ b/src/file.ts
@@ -1202,8 +1202,8 @@ export const COMMON_MIME_TYPES: Map<string, string> = new Map([
     ['zsh', 'text/x-scriptzsh']
 ]);
 
-export function toFileWithPath(file: FileWithPath, path?: string, h?: FileSystemHandle): FileWithPath {
-    const f = withMimeType(file);
+export function toFileWithPath(file: File, path?: string, h?: FileSystemHandle): FileWithPath {
+    const f = withMimeType(file) as FileWithPath;
     const {webkitRelativePath} = file;
     const p =
         typeof path === 'string'
@@ -1232,12 +1232,12 @@ export function toFileWithPath(file: FileWithPath, path?: string, h?: FileSystem
 }
 
 export interface FileWithPath extends File {
-    readonly path?: string;
+    readonly path: string;
+    readonly relativePath: string;
     readonly handle?: FileSystemFileHandle;
-    readonly relativePath?: string;
 }
 
-function withMimeType(file: FileWithPath) {
+function withMimeType(file: File) {
     const {name} = file;
     const hasExtension = name && name.lastIndexOf('.') !== -1;
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- [x] Bug Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Style
- [ ] Build
- [ ] Chore
- [ ] Documentation
- [ ] CI

**Did you add tests for your changes?**
- [x] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**
- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**

Fix https://github.com/react-dropzone/file-selector/issues/115.

**Does this PR introduce a breaking change?**

No.

**Other information**

Stacked on top of:
1. https://github.com/react-dropzone/file-selector/pull/133
2. https://github.com/react-dropzone/file-selector/pull/135
3. https://github.com/react-dropzone/file-selector/pull/136
4. https://github.com/react-dropzone/file-selector/pull/137