### PR TITLE
fix: fall back to getAsFile when getAsFileSystemHandle returns null

### DIFF
--- a/e2e/drag-drop.e2e.ts
+++ b/e2e/drag-drop.e2e.ts
@@ -16,6 +16,16 @@ test("drops a flat set of files and returns them", async ({page}) => {
   expect(files.every(f => f.hasHandle)).toBe(true);
 });
 
+test("drops a single file and returns it", async ({page}) => {
+  await cdpDrop(page, [fixture("files/hello.json")]);
+
+  const files = await readResult(page);
+  expect(files.map(f => f.name)).toEqual(["hello.json"]);
+  expect(files.map(f => f.path)).toEqual(["./hello.json"]);
+  expect(files[0].isFile).toBe(true);
+  expect(files[0].hasHandle).toBe(true);
+});
+
 test("drops a directory and flattens it recursively", async ({page}) => {
   await cdpDrop(page, [fixture("tree")]);
 
@@ -24,4 +34,32 @@ test("drops a directory and flattens it recursively", async ({page}) => {
   expect(files.map(f => f.name).sort()).toEqual(["ping.json", "pong.json"]);
   expect(files.map(f => f.path).sort()).toEqual(["/tree/nested/pong.json", "/tree/ping.json"]);
   expect(files.every(f => f.hasHandle)).toBe(true);
+});
+
+test("drops files alongside a directory and flattens everything", async ({page}) => {
+  // Exercises the plain-file path and directory traversal in a single drop.
+  await cdpDrop(page, [fixture("files/hello.json"), fixture("tree")]);
+
+  const files = await readResult(page);
+  expect(files.map(f => f.name).sort()).toEqual(["hello.json", "ping.json", "pong.json"]);
+  expect(files.map(f => f.path).sort()).toEqual(["./hello.json", "/tree/nested/pong.json", "/tree/ping.json"]);
+});
+
+test("recovers the dropped file when getAsFileSystemHandle resolves to null (issue #1435)", async ({page}) => {
+  // Chromium hands back a null FileSystemHandle for items with no backing handle, e.g. a file
+  // dragged out of a Windows archive. Reproduce that on a *real* drag by stubbing only the handle
+  // API to resolve null on a later task. This keeps the genuine neuter timing: getAsFile() only
+  // still works if file-selector captured it synchronously, before awaiting the handle.
+  // https://github.com/react-dropzone/react-dropzone/issues/1435
+  await page.evaluate(() => {
+    const proto = (globalThis as unknown as {DataTransferItem: {prototype: any}}).DataTransferItem.prototype;
+    proto.getAsFileSystemHandle = () => new Promise(resolve => setTimeout(() => resolve(null), 0));
+  });
+
+  await cdpDrop(page, [fixture("files/hello.json")]);
+
+  const files = await readResult(page);
+  expect(files.map(f => f.name)).toEqual(["hello.json"]);
+  // No handle available => the file came from the synchronously-captured getAsFile() fallback.
+  expect(files[0].hasHandle).toBe(false);
 });

--- a/src/file-selector.spec.ts
+++ b/src/file-selector.spec.ts
@@ -423,6 +423,36 @@ it("should fallback to getAsFile when getAsFileSystemHandle resolves to undefine
   expect(file.path).toBe(`./${name}`);
 });
 
+it("falls back to getAsFile when getAsFileSystemHandle resolves to null (issue #1435)", async () => {
+  // Chromium returns a null FileSystemHandle for items with no backing handle, e.g. a file
+  // dragged out of a Windows archive. The item still has a File via getAsFile(), so the drop
+  // must not be lost. See https://github.com/react-dropzone/react-dropzone/issues/1435
+  const name = "from-archive.txt";
+  const mockFile = createFile(name, {ping: true}, {type: "text/plain"});
+  const evt = dragEvtFromItems([dataTransferItemWithFsHandle(mockFile, null)]);
+
+  const files = await fromEvent(evt);
+  expect(files).toHaveLength(1);
+  expect(files.every(file => file instanceof File)).toBe(true);
+
+  const [file] = files as FileWithPath[];
+  expect(file.name).toBe(name);
+  expect(file.path).toBe(`./${name}`);
+});
+
+it("reads getAsFile() synchronously so awaiting getAsFileSystemHandle can't neuter it (issue #1435)", async () => {
+  // Faithful to real Chromium: getAsFileSystemHandle() resolves on a *later task*, and by the
+  // time it resolves the DataTransferItem has been neutered so getAsFile() returns null. The
+  // File must be captured synchronously (before the await) or the drop is silently lost.
+  const name = "neutered.txt";
+  const mockFile = createFile(name, {ping: true}, {type: "text/plain"});
+  const evt = dragEvtFromItems([dataTransferItemThatNeutersAfterHandleAwait(mockFile)]);
+
+  const files = await fromEvent(evt);
+  expect(files).toHaveLength(1);
+  expect((files[0] as FileWithPath).name).toBe(name);
+});
+
 it("guesses the {type} from the extension using the built-in defaults", async () => {
   const mockFile = createFile("test.png", {ping: true}); // typeless File
   const evt = inputEvtFromFiles(mockFile);
@@ -525,6 +555,28 @@ function dataTransferItemWithFsHandle(file?: File | null, h?: FileSystemFileHand
     },
     getAsFileSystemHandle() {
       return Promise.resolve(h);
+    }
+  } as any;
+}
+
+// Models a Chromium file item (e.g. dragged out of an archive) that exposes no FileSystemHandle
+// and neuters once the getAsFileSystemHandle() promise resolves on a later task, mirroring the
+// behaviour measured in a real browser: getAsFile() only works synchronously, and
+// getAsFileSystemHandle() resolves to null after a macrotask.
+function dataTransferItemThatNeutersAfterHandleAwait(file: File): DataTransferItem {
+  let neutered = false;
+  return {
+    kind: "file",
+    getAsFile() {
+      return neutered ? null : file;
+    },
+    getAsFileSystemHandle() {
+      return new Promise(resolve =>
+        setTimeout(() => {
+          neutered = true;
+          resolve(null);
+        }, 0)
+      );
     }
   } as any;
 }

--- a/src/file-selector.ts
+++ b/src/file-selector.ts
@@ -146,25 +146,30 @@ function flatten<T>(items: any[]): T[] {
 }
 
 async function fromDataTransferItem(item: DataTransferItem, entry?: FileSystemEntry | null) {
+  // Read the File synchronously, before awaiting anything. A DataTransferItem's accessors are
+  // only valid during the synchronous part of the drop event; awaiting `getAsFileSystemHandle()`
+  // (which resolves on a later task) neuters the item in Chromium, after which `getAsFile()`
+  // returns `null`. Capturing it up front lets us recover the drop when no handle is available.
+  // See https://github.com/react-dropzone/react-dropzone/issues/1435
+  const syncFile = item.getAsFile();
+
   const h = await getFsHandle(item);
-  if (h === null) {
-    throw new UnexpectedObjectError(item);
-  }
-  // It seems that the handle can be `undefined` (see https://github.com/react-dropzone/file-selector/issues/120),
-  // so we check if it isn't; if it is, the code path continues to the next API (`getAsFile`).
-  // The handle is also `undefined` when the File System Access API isn't available or we're not
-  // in a secure context, in which case we likewise fall back to `getAsFile`.
-  if (h !== undefined) {
+  // Prefer the File System Access handle when we got one: it carries a durable handle (and, for
+  // cross-window drops, the freshest File).
+  if (h !== null && h !== undefined) {
     const file = await h.getFile();
     file.handle = h;
     return toFileWithPath(file);
   }
-  const file = item.getAsFile();
-  if (!file) {
+  // No usable handle. `h` is `null` when Chromium has no backing handle for the item (e.g. a file
+  // dragged out of an archive — see the issue above) and `undefined` when the File System Access
+  // API is unavailable or we're not in a secure context (see
+  // https://github.com/react-dropzone/file-selector/issues/120). In both cases fall back to the
+  // File we captured synchronously rather than throwing or re-reading a now-neutered item.
+  if (!syncFile) {
     throw new UnexpectedObjectError(item);
   }
-  const fwp = toFileWithPath(file, entry?.fullPath ?? undefined);
-  return fwp;
+  return toFileWithPath(syncFile, entry?.fullPath ?? undefined);
 }
 
 // Resolve the https://developer.mozilla.org/en-US/docs/Web/API/FileSystemHandle for a dropped item.


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- [x] Bug Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Style
- [ ] Build
- [ ] Chore
- [ ] Documentation
- [ ] CI

**Did you add tests for your changes?**
- [x] Yes, my code is well tested
- [ ] Not relevant

**If relevant, did you update the documentation?**
- [ ] Yes, I've updated the documentation
- [x] Not relevant

**Summary**

Fix https://github.com/react-dropzone/react-dropzone/issues/1435.

**Does this PR introduce a breaking change?**

No.

**Other information**
